### PR TITLE
refactor: replace ferrumx-windows with cimari

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dependency versions -->
-        <ferrumx.windows.version>4.1.0</ferrumx.windows.version>
+        <cimari.version>0.1.0</cimari.version>
         <dmidecode4j.version>0.3.0</dmidecode4j.version>
         <swing.theme.manager>0.1.0</swing.theme.manager>
         <slf4j.version>2.0.17</slf4j.version>
@@ -51,8 +51,8 @@
     <dependencies>
         <dependency>
             <groupId>io.github.eggy03</groupId>
-            <artifactId>ferrumx-windows</artifactId>
-            <version>${ferrumx.windows.version}</version>
+            <artifactId>cimari</artifactId>
+            <version>${cimari.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/github/eggy03/ui/common/ui/AboutUI.java
+++ b/src/main/java/io/github/eggy03/ui/common/ui/AboutUI.java
@@ -43,7 +43,7 @@ public class AboutUI extends JFrame {
 			<b>Open-Source Licenses</b><br>
 			This application includes the following third-party open-source libraries and frameworks:
 			<ul>
-			  <li>FerrumX Windows</li>
+			  <li>cimari</li>
 			  <li>dmidecode4j</li>
 			  <li>Swing Theme Manager</li>
 			  <li>Apache Commons Lang</li>

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIBaseboardWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIBaseboardWorker.java
@@ -4,8 +4,9 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.mainboard.Win32Baseboard;
-import io.github.eggy03.ferrumx.windows.service.mainboard.Win32BaseboardService;
+import io.github.eggy03.cimari.entity.mainboard.ImmutableWin32Baseboard;
+import io.github.eggy03.cimari.entity.mainboard.Win32Baseboard;
+import io.github.eggy03.cimari.service.mainboard.Win32BaseboardService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,13 +70,13 @@ public class WMIBaseboardWorker extends SwingWorker<List<Win32Baseboard>, Void> 
     private void populateFields(Map<Integer, Win32Baseboard> baseboardMap) {
 
         Integer selectedBaseboardChoice = (Integer) baseboardNumberComboBox.getSelectedItem();
-        Win32Baseboard baseboard = baseboardMap.getOrDefault(selectedBaseboardChoice, Win32Baseboard.builder().build());
+        Win32Baseboard baseboard = baseboardMap.getOrDefault(selectedBaseboardChoice, new ImmutableWin32Baseboard.Builder().build());
 
-        baseboardFields.get(0).setText(baseboard.getManufacturer());
-        baseboardFields.get(1).setText(baseboard.getModel());
-        baseboardFields.get(2).setText(baseboard.getProduct());
-        baseboardFields.get(3).setText(baseboard.getSerialNumber());
-        baseboardFields.get(4).setText(baseboard.getVersion());
+        baseboardFields.get(0).setText(baseboard.manufacturer());
+        baseboardFields.get(1).setText(baseboard.model());
+        baseboardFields.get(2).setText(baseboard.product());
+        baseboardFields.get(3).setText(baseboard.serialNumber());
+        baseboardFields.get(4).setText(baseboard.version());
 
     }
 

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIBiosWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIBiosWorker.java
@@ -4,8 +4,9 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.mainboard.Win32Bios;
-import io.github.eggy03.ferrumx.windows.service.mainboard.Win32BiosService;
+import io.github.eggy03.cimari.entity.mainboard.ImmutableWin32Bios;
+import io.github.eggy03.cimari.entity.mainboard.Win32Bios;
+import io.github.eggy03.cimari.service.mainboard.Win32BiosService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.utilities.WMIDateUtility;
 import lombok.RequiredArgsConstructor;
@@ -76,27 +77,27 @@ public class WMIBiosWorker extends SwingWorker<List<Win32Bios>, Void> {
 
         Integer selectedBiosNumber = (Integer) biosNumberComboBox.getSelectedItem();
 
-        Win32Bios bios = biosMap.getOrDefault(selectedBiosNumber, Win32Bios.builder().build());
+        Win32Bios bios = biosMap.getOrDefault(selectedBiosNumber, new ImmutableWin32Bios.Builder().build());
 
-        biosFields.get(0).setText(bios.getCaption());
-        biosFields.get(1).setText(bios.getCurrentLanguage());
-        biosFields.get(2).setText(bios.getManufacturer());
-        biosFields.get(3).setText(bios.getName());
+        biosFields.get(0).setText(bios.caption());
+        biosFields.get(1).setText(bios.currentLanguage());
+        biosFields.get(2).setText(bios.manufacturer());
+        biosFields.get(3).setText(bios.name());
 
-        biosFields.get(5).setText(WMIDateUtility.toLocalDateTime(bios.getReleaseDate()));
+        biosFields.get(5).setText(WMIDateUtility.toLocalDateTime(bios.releaseDate()));
 
-        biosFields.get(7).setText(bios.getSmbiosBiosVersion());
-        biosFields.get(8).setText(bios.getStatus());
-        biosFields.get(9).setText(bios.getVersion());
+        biosFields.get(7).setText(bios.smbiosBiosVersion());
+        biosFields.get(8).setText(bios.status());
+        biosFields.get(9).setText(bios.version());
 
         // this is so bad....I cant use inline expression or sonar will detect it
-        Boolean primaryBios = bios.isPrimaryBios();
+        Boolean primaryBios = bios.primaryBios();
         if(primaryBios!=null) {
             if(primaryBios) biosFields.get(4).setText("Yes");
             else biosFields.get(4).setText("No");
         } else biosFields.get(4).setText("N/A");
 
-        Boolean smbiosPresent = bios.isSMBIOSPresent();
+        Boolean smbiosPresent = bios.smbiosPresent();
         if(smbiosPresent!=null) {
             if(smbiosPresent) biosFields.get(6).setText("Yes");
             else biosFields.get(6).setText("No");

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIHardwareIdWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIHardwareIdWorker.java
@@ -4,8 +4,9 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.compounded.HardwareId;
-import io.github.eggy03.ferrumx.windows.service.compounded.HardwareIdService;
+import io.github.eggy03.cimari.entity.compounded.HardwareId;
+import io.github.eggy03.cimari.entity.compounded.ImmutableHardwareId;
+import io.github.eggy03.cimari.service.compounded.HardwareIdService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,7 @@ public class WMIHardwareIdWorker extends SwingWorker<HardwareId, Void>{
 
 	@Override
 	protected HardwareId doInBackground() {
-		return new HardwareIdService().get(TerminalConstant.TIMEOUT_SIXTY_SECONDS).orElse(HardwareId.builder().build());
+		return new HardwareIdService().get(TerminalConstant.TIMEOUT_SIXTY_SECONDS).orElse(new ImmutableHardwareId.Builder().build());
 		// I wonder if I should throw an exception or just return an empty build
 	}
 	
@@ -31,7 +32,7 @@ public class WMIHardwareIdWorker extends SwingWorker<HardwareId, Void>{
 		
 		try {
 			HardwareId hwid = get();
-			hwidField.setText(hwid.getHashHWID());
+			hwidField.setText(hwid.hashHWID());
 		} catch (ExecutionException e) {
 			log.error("HWID Fetch Failed", e);
 		} catch (InterruptedException e) {

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMINetworkPanelWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMINetworkPanelWorker.java
@@ -4,12 +4,12 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.compounded.MsftNetAdapterToIpAndDnsAndProfile;
-import io.github.eggy03.ferrumx.windows.entity.network.MsftDnsClientServerAddress;
-import io.github.eggy03.ferrumx.windows.entity.network.MsftNetAdapter;
-import io.github.eggy03.ferrumx.windows.entity.network.MsftNetConnectionProfile;
-import io.github.eggy03.ferrumx.windows.entity.network.MsftNetIpAddress;
-import io.github.eggy03.ferrumx.windows.service.compounded.MsftNetAdapterToIpAndDnsAndProfileService;
+import io.github.eggy03.cimari.entity.compounded.MsftNetAdapterToIpAndDnsAndProfile;
+import io.github.eggy03.cimari.entity.network.MsftDnsClientServerAddress;
+import io.github.eggy03.cimari.entity.network.MsftNetAdapter;
+import io.github.eggy03.cimari.entity.network.MsftNetConnectionProfile;
+import io.github.eggy03.cimari.entity.network.MsftNetIpAddress;
+import io.github.eggy03.cimari.service.compounded.MsftNetAdapterToIpAndDnsAndProfileService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.constant.WMIConstants;
 import io.github.eggy03.ui.windows.utilities.WMIBooleanUtility;
@@ -22,6 +22,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -49,7 +50,7 @@ public class WMINetworkPanelWorker extends SwingWorker<List<MsftNetAdapterToIpAn
             log.info("Found {} MsftNetAdapter entry/entries", netList.size());
 
             // populate the combo box with network interface indexes
-            netList.forEach(net-> networkIndexComboBox.addItem(net.getInterfaceIndex()));
+            netList.forEach(net-> networkIndexComboBox.addItem(net.interfaceIndex()));
             // populate fields and editor panes for the first entry in the combo box
             populate(netList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -72,36 +73,35 @@ public class WMINetworkPanelWorker extends SwingWorker<List<MsftNetAdapterToIpAn
         Long interfaceIndex = Long.valueOf(selectedItem);
         Optional<MsftNetAdapterToIpAndDnsAndProfile> currentNetOptional = netList
                 .stream()
-                .filter(net->
-                        net.getInterfaceIndex()!=null && net.getInterfaceIndex().equals(interfaceIndex)
-                )
+                .filter(Objects::nonNull)
+                .filter(net-> Objects.equals(net.interfaceIndex(), interfaceIndex))
                 .findFirst();
 
         if(currentNetOptional.isEmpty())
             return;
 
         MsftNetAdapterToIpAndDnsAndProfile currentNet = currentNetOptional.get();
-        MsftNetAdapter currentAdapter = currentNet.getAdapter();
-        List<MsftNetIpAddress> currentNetIpAddressList = currentNet.getIpAddressList();
-        List<MsftDnsClientServerAddress> currentDnsAddressList = currentNet.getDnsClientServerAddressList();
-        List<MsftNetConnectionProfile> currentConnectionProfileList = currentNet.getNetConnectionProfileList();
+        MsftNetAdapter currentAdapter = currentNet.adapter();
+        List<MsftNetIpAddress> currentNetIpAddressList = currentNet.ipAddressList();
+        List<MsftDnsClientServerAddress> currentDnsAddressList = currentNet.dnsClientServerAddressList();
+        List<MsftNetConnectionProfile> currentConnectionProfileList = currentNet.netConnectionProfileList();
 
         if(currentAdapter!=null){
-            networkFields.get(0).setText(currentAdapter.getDeviceId());
-            networkFields.get(1).setText(currentAdapter.getInterfaceDescription());
-            networkFields.get(2).setText(currentAdapter.getDriverVersion());
-            networkFields.get(3).setText(currentAdapter.getDriverDate());
-            networkFields.get(4).setText(String.valueOf(currentAdapter.getInterfaceType())); //not parsed cause long list
-            networkFields.get(5).setText(currentAdapter.getLinkLayerAddress());
-            networkFields.get(6).setText(currentAdapter.getLinkSpeed());
-            networkFields.get(7).setText(WMIConstants.resolveMsftNetAdapterMediaConnectState(currentAdapter.getMediaConnectState()));
-            networkFields.get(8).setText(currentAdapter.getMediaType());
-            networkFields.get(9).setText(WMINetworkUtility.resolveNetworkSpeedInMbps(currentAdapter.getReceiveLinkSpeedRaw()));
-            networkFields.get(10).setText(WMINetworkUtility.resolveNetworkSpeedInMbps(currentAdapter.getTransmitLinkSpeedRaw()));
-            networkFields.get(11).setText(WMIBooleanUtility.resolveBoolean(currentAdapter.isFullDuplex()));
-            networkFields.get(12).setText(WMIBooleanUtility.resolveBoolean(currentAdapter.isVirtual()));
-            networkFields.get(13).setText(currentAdapter.getStatus());
-            networkFields.get(14).setText(currentAdapter.getPnpDeviceId());
+            networkFields.get(0).setText(currentAdapter.deviceId());
+            networkFields.get(1).setText(currentAdapter.interfaceDescription());
+            networkFields.get(2).setText(currentAdapter.driverVersion());
+            networkFields.get(3).setText(currentAdapter.driverDate());
+            networkFields.get(4).setText(String.valueOf(currentAdapter.interfaceType())); //not parsed cause long list
+            networkFields.get(5).setText(currentAdapter.linkLayerAddress());
+            networkFields.get(6).setText(currentAdapter.linkSpeed());
+            networkFields.get(7).setText(WMIConstants.resolveMsftNetAdapterMediaConnectState(currentAdapter.mediaConnectState()));
+            networkFields.get(8).setText(currentAdapter.mediaType());
+            networkFields.get(9).setText(WMINetworkUtility.resolveNetworkSpeedInMbps(currentAdapter.receiveLinkSpeedRaw()));
+            networkFields.get(10).setText(WMINetworkUtility.resolveNetworkSpeedInMbps(currentAdapter.transmitLinkSpeedRaw()));
+            networkFields.get(11).setText(WMIBooleanUtility.resolveBoolean(currentAdapter.fullDuplex()));
+            networkFields.get(12).setText(WMIBooleanUtility.resolveBoolean(currentAdapter.virtual()));
+            networkFields.get(13).setText(currentAdapter.status());
+            networkFields.get(14).setText(currentAdapter.pnpDeviceId());
         }
 
         JEditorPane ipAddressPane = networkEditorPanes.get(0);
@@ -118,14 +118,14 @@ public class WMINetworkPanelWorker extends SwingWorker<List<MsftNetAdapterToIpAn
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("<html><body>");
             currentNetIpAddressList.forEach(ip -> stringBuilder
-                    .append("<b>IP Interface Index:</b> ").append(ip.getInterfaceIndex()).append("<br>")
-                    .append("<b>IP Interface Alias:</b> ").append(ip.getInterfaceAlias()).append("<br>")
-                    .append("<b>Address Family:</b> ").append(WMIConstants.resolveMsftIPvAddressFamily(ip.getAddressFamily())).append("<br>")
-                    .append("<b>IPv4 Address:</b> ").append(ip.getIpv4Address()).append("<br>")
-                    .append("<b>IPv6 Address:</b> ").append(ip.getIpv6Address()).append("<br>")
-                    .append("<b>Type:</b> ").append(WMIConstants.resolveMsftNetIpAddressType(ip.getType())).append("<br>")
-                    .append("<b>Prefix Origin:</b> ").append(WMIConstants.resolveMsftNetIpAddressPrefixOrigin(ip.getPrefixOrigin())).append("<br>")
-                    .append("<b>Suffix Origin:</b> ").append(WMIConstants.resolveMsftNetIpAddressSuffixOrigin(ip.getSuffixOrigin())).append("<br><br>")
+                    .append("<b>IP Interface Index:</b> ").append(ip.interfaceIndex()).append("<br>")
+                    .append("<b>IP Interface Alias:</b> ").append(ip.interfaceAlias()).append("<br>")
+                    .append("<b>Address Family:</b> ").append(WMIConstants.resolveMsftIPvAddressFamily(ip.addressFamily())).append("<br>")
+                    .append("<b>IPv4 Address:</b> ").append(ip.ipv4Address()).append("<br>")
+                    .append("<b>IPv6 Address:</b> ").append(ip.ipv6Address()).append("<br>")
+                    .append("<b>Type:</b> ").append(WMIConstants.resolveMsftNetIpAddressType(ip.type())).append("<br>")
+                    .append("<b>Prefix Origin:</b> ").append(WMIConstants.resolveMsftNetIpAddressPrefixOrigin(ip.prefixOrigin())).append("<br>")
+                    .append("<b>Suffix Origin:</b> ").append(WMIConstants.resolveMsftNetIpAddressSuffixOrigin(ip.suffixOrigin())).append("<br><br>")
             );
             stringBuilder.append("</body></html>");
 
@@ -137,10 +137,10 @@ public class WMINetworkPanelWorker extends SwingWorker<List<MsftNetAdapterToIpAn
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("<html><body>");
             currentDnsAddressList.forEach(dns -> stringBuilder
-                    .append("<b>DNS Interface Index:</b> ").append(dns.getInterfaceIndex()).append("<br>")
-                    .append("<b>DNS Interface Alias:</b> ").append(dns.getInterfaceAlias()).append("<br>")
-                    .append("<b>Address Family:</b> ").append(WMIConstants.resolveMsftIPvAddressFamily(dns.getAddressFamily())).append("<br>")
-                    .append("<b>DNS Server Addresses:</b> ").append(dns.getDnsServerAddresses()).append("<br><br>")
+                    .append("<b>DNS Interface Index:</b> ").append(dns.interfaceIndex()).append("<br>")
+                    .append("<b>DNS Interface Alias:</b> ").append(dns.interfaceAlias()).append("<br>")
+                    .append("<b>Address Family:</b> ").append(WMIConstants.resolveMsftIPvAddressFamily(dns.addressFamily())).append("<br>")
+                    .append("<b>DNS Server Addresses:</b> ").append(dns.dnsServerAddresses()).append("<br><br>")
             );
             stringBuilder.append("</body></html>");
 
@@ -152,12 +152,12 @@ public class WMINetworkPanelWorker extends SwingWorker<List<MsftNetAdapterToIpAn
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("<html><body>");
             currentConnectionProfileList.forEach(profile -> stringBuilder
-                    .append("<b>Profile Interface Index:</b> ").append(profile.getInterfaceIndex()).append("<br>")
-                    .append("<b>Connection Interface Alias:</b> ").append(profile.getInterfaceAlias()).append("<br>")
-                    .append("<b>Category:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileNetworkCategory(profile.getNetworkCategory())).append("<br>")
-                    .append("<b>Domain Auth Kind:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileDomainAuthenticationKind(profile.getDomainAuthenticationKind())).append("<br>")
-                    .append("<b>IPv4 Connectivity:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileConnectivity(profile.getIpv4Connectivity())).append("<br>")
-                    .append("<b>IPv6 Connectivity:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileConnectivity(profile.getIpv6Connectivity())).append("<br><br>")
+                    .append("<b>Profile Interface Index:</b> ").append(profile.interfaceIndex()).append("<br>")
+                    .append("<b>Connection Interface Alias:</b> ").append(profile.interfaceAlias()).append("<br>")
+                    .append("<b>Category:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileNetworkCategory(profile.networkCategory())).append("<br>")
+                    .append("<b>Domain Auth Kind:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileDomainAuthenticationKind(profile.domainAuthenticationKind())).append("<br>")
+                    .append("<b>IPv4 Connectivity:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileConnectivity(profile.ipv4Connectivity())).append("<br>")
+                    .append("<b>IPv6 Connectivity:</b> ").append(WMIConstants.resolveMsftNetConnectionProfileConnectivity(profile.ipv6Connectivity())).append("<br><br>")
             );
             stringBuilder.append("</body></html>");
 

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIOperatingSystemWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIOperatingSystemWorker.java
@@ -4,8 +4,8 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.system.Win32OperatingSystem;
-import io.github.eggy03.ferrumx.windows.service.system.Win32OperatingSystemService;
+import io.github.eggy03.cimari.entity.system.Win32OperatingSystem;
+import io.github.eggy03.cimari.service.system.Win32OperatingSystemService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.utilities.WMIBooleanUtility;
 import io.github.eggy03.ui.windows.utilities.WMIDateUtility;
@@ -17,6 +17,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -44,7 +45,7 @@ public class WMIOperatingSystemWorker extends SwingWorker<List<Win32OperatingSys
             log.info("Found {} Win32OperatingSystem entry/entries", osList.size());
 
             // fill the combo box with os names
-            osList.forEach(os -> osNameComboBox.addItem(os.getName()));
+            osList.forEach(os -> osNameComboBox.addItem(os.name()));
             // populate fields for the first entry in the combo box
             populateFields(osList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -64,7 +65,8 @@ public class WMIOperatingSystemWorker extends SwingWorker<List<Win32OperatingSys
 
         Optional<Win32OperatingSystem> optionalOs = osList
                 .stream()
-                .filter(os-> os.getName()!=null && os.getName().equals(osName))
+                .filter(Objects::nonNull)
+                .filter(os-> Objects.equals(os.name(), osName))
                 .findFirst();
 
         if(optionalOs.isEmpty())
@@ -72,34 +74,34 @@ public class WMIOperatingSystemWorker extends SwingWorker<List<Win32OperatingSys
 
         Win32OperatingSystem os = optionalOs.get();
 
-        osFields.get(0).setText(os.getCaption());
-        osFields.get(1).setText(os.getVersion());
-        osFields.get(2).setText(os.getBuildNumber());
-        osFields.get(3).setText(os.getManufacturer());
-        osFields.get(4).setText(os.getOsArchitecture());
-        osFields.get(5).setText(WMIDateUtility.toLocalDateTime(os.getInstallDate()));
-        osFields.get(6).setText(WMIDateUtility.toLocalDateTime(os.getLastBootUpTime()));
-        osFields.get(7).setText(os.getSerialNumber());
-        osFields.get(8).setText(os.getMuiLanguages()==null ? "N/A" : os.getMuiLanguages().toString());
-        osFields.get(9).setText(WMIBooleanUtility.resolveBoolean(os.isPrimary()));
-        osFields.get(10).setText(WMIBooleanUtility.resolveBoolean(os.isDistributed()));
-        osFields.get(11).setText(WMIBooleanUtility.resolveBoolean(os.isPortable()));
-        osFields.get(12).setText(os.getCsName());
-        osFields.get(13).setText(String.valueOf(os.getNumberOfUsers()));
-        osFields.get(14).setText(os.getRegisteredUser());
-        osFields.get(15).setText(os.getSystemDrive());
-        osFields.get(16).setText(os.getWindowsDirectory());
-        osFields.get(17).setText(os.getSystemDirectory());
+        osFields.get(0).setText(os.caption());
+        osFields.get(1).setText(os.version());
+        osFields.get(2).setText(os.buildNumber());
+        osFields.get(3).setText(os.manufacturer());
+        osFields.get(4).setText(os.osArchitecture());
+        osFields.get(5).setText(WMIDateUtility.toLocalDateTime(os.installDate()));
+        osFields.get(6).setText(WMIDateUtility.toLocalDateTime(os.lastBootUpTime()));
+        osFields.get(7).setText(os.serialNumber());
+        osFields.get(8).setText(os.muiLanguages()==null ? "N/A" : os.muiLanguages().toString());
+        osFields.get(9).setText(WMIBooleanUtility.resolveBoolean(os.primary()));
+        osFields.get(10).setText(WMIBooleanUtility.resolveBoolean(os.distributed()));
+        osFields.get(11).setText(WMIBooleanUtility.resolveBoolean(os.portableOperatingSystem()));
+        osFields.get(12).setText(os.csName());
+        osFields.get(13).setText(String.valueOf(os.numberOfUsers()));
+        osFields.get(14).setText(os.registeredUser());
+        osFields.get(15).setText(os.systemDrive());
+        osFields.get(16).setText(os.windowsDirectory());
+        osFields.get(17).setText(os.systemDirectory());
 
-        String conciseOsText = os.getOsArchitecture() + " edition of Windows" +
+        String conciseOsText = os.osArchitecture() + " edition of Windows" +
                 System.lineSeparator() +
-                "Version: " + os.getVersion() +
+                "Version: " + os.version() +
                 System.lineSeparator() +
-                "Installed on: " + WMIDateUtility.toLocalDateTime(os.getInstallDate()) +
+                "Installed on: " + WMIDateUtility.toLocalDateTime(os.installDate()) +
                 System.lineSeparator() +
-                "Last started on: " + WMIDateUtility.toLocalDateTime(os.getLastBootUpTime()) +
+                "Last started on: " + WMIDateUtility.toLocalDateTime(os.lastBootUpTime()) +
                 System.lineSeparator() +
-                "Registered to: " + os.getRegisteredUser();
+                "Registered to: " + os.registeredUser();
 
         osConciseInfoArea.setText(conciseOsText);
     }

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIPhysicalMemoryPanelWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIPhysicalMemoryPanelWorker.java
@@ -4,8 +4,8 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.memory.Win32PhysicalMemory;
-import io.github.eggy03.ferrumx.windows.service.memory.Win32PhysicalMemoryService;
+import io.github.eggy03.cimari.entity.memory.Win32PhysicalMemory;
+import io.github.eggy03.cimari.service.memory.Win32PhysicalMemoryService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.utilities.WMISizeUtility;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +15,7 @@ import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -44,7 +45,7 @@ public class WMIPhysicalMemoryPanelWorker extends SwingWorker<List<Win32Physical
             log.info("Found {} Win32PhysicalMemory entry/entries", physicalMemoryList.size());
 
             // fill the combo box with memory tags
-            physicalMemoryList.forEach(memory -> memoryTagComboBox.addItem(memory.getTag()));
+            physicalMemoryList.forEach(memory -> memoryTagComboBox.addItem(memory.tag()));
             // populate fields for the first entry in the combo box
             populateMemoryFields(physicalMemoryList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -67,7 +68,8 @@ public class WMIPhysicalMemoryPanelWorker extends SwingWorker<List<Win32Physical
         // from the memory list, filter the memory module based on the selected tag
         Optional<Win32PhysicalMemory> selectedMemory = physicalMemoryList
                 .stream()
-                .filter(memory ->  memory.getTag()!=null && memory.getTag().equals(memoryTag))
+                .filter(Objects::nonNull)
+                .filter(memory -> Objects.equals(memory.tag(), memoryTag))
                 .findFirst(); // tag is a unique ID, and it will always return at most 1 Win32PhysicalMemory object
 
         if (selectedMemory.isEmpty())
@@ -76,19 +78,19 @@ public class WMIPhysicalMemoryPanelWorker extends SwingWorker<List<Win32Physical
         Win32PhysicalMemory memory = selectedMemory.get();
 
         // populate the fields
-        memoryFields.get(0).setText(memory.getName());
-        memoryFields.get(1).setText(memory.getManufacturer());
-        memoryFields.get(2).setText(memory.getModel());
-        memoryFields.get(3).setText(memory.getOtherIdentifyingInfo());
-        memoryFields.get(4).setText(memory.getPartNumber());
-        memoryFields.get(5).setText(memory.getSerialNumber());
-        memoryFields.get(6).setText(resolveWMIPhysicalMemoryFormFactor(memory.getFormFactor()));
-        memoryFields.get(7).setText(memory.getBankLabel());
-        memoryFields.get(8).setText(WMISizeUtility.parseToGBString(memory.getCapacity()));
-        memoryFields.get(9).setText(memory.getDataWidth()+ " Bits");
-        memoryFields.get(10).setText(memory.getSpeed()+ " MHz");
-        memoryFields.get(11).setText(memory.getConfiguredClockSpeed()+ " MHz");
-        memoryFields.get(12).setText(memory.getDeviceLocator());
+        memoryFields.get(0).setText(memory.name());
+        memoryFields.get(1).setText(memory.manufacturer());
+        memoryFields.get(2).setText(memory.model());
+        memoryFields.get(3).setText(memory.otherIdentifyingInfo());
+        memoryFields.get(4).setText(memory.partNumber());
+        memoryFields.get(5).setText(memory.serialNumber());
+        memoryFields.get(6).setText(resolveWMIPhysicalMemoryFormFactor(memory.formFactor()));
+        memoryFields.get(7).setText(memory.bankLabel());
+        memoryFields.get(8).setText(WMISizeUtility.parseToGBString(memory.capacity()));
+        memoryFields.get(9).setText(memory.dataWidth()+ " Bits");
+        memoryFields.get(10).setText(memory.speed()+ " MHz");
+        memoryFields.get(11).setText(memory.configuredClockSpeed()+ " MHz");
+        memoryFields.get(12).setText(memory.deviceLocator());
 
     }
 }

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIPortConnectorWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIPortConnectorWorker.java
@@ -4,8 +4,8 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.mainboard.Win32PortConnector;
-import io.github.eggy03.ferrumx.windows.service.mainboard.Win32PortConnectorService;
+import io.github.eggy03.cimari.entity.mainboard.Win32PortConnector;
+import io.github.eggy03.cimari.service.mainboard.Win32PortConnectorService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +14,7 @@ import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -43,7 +44,7 @@ public class WMIPortConnectorWorker extends SwingWorker<List<Win32PortConnector>
             log.info("Found {} Win32PortConnector entry/entries", portList.size());
 
             //fill the combo box with port connector tags
-            portList.forEach(port-> tagComboBox.addItem(port.getTag()));
+            portList.forEach(port-> tagComboBox.addItem(port.tag()));
             // populate fields for the first entry in the combo box
             populatePortConnectorFields(portList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -64,15 +65,16 @@ public class WMIPortConnectorWorker extends SwingWorker<List<Win32PortConnector>
 
         Optional<Win32PortConnector> selectedPort = portList
                 .stream()
-                .filter(port -> port.getTag()!=null && port.getTag().equals(selectedTag))
+                .filter(Objects::nonNull)
+                .filter(port -> Objects.equals(port.tag(), selectedTag))
                 .findFirst();
 
         if(selectedPort.isEmpty())
             return;
 
         Win32PortConnector port = selectedPort.get();
-        portFields.get(0).setText(resolveWMIPortType(port.getPortType()));
-        portFields.get(1).setText(port.getInternalReferenceDesignator());
-        portFields.get(2).setText(port.getExternalReferenceDesignator());
+        portFields.get(0).setText(resolveWMIPortType(port.portType()));
+        portFields.get(1).setText(port.internalReferenceDesignator());
+        portFields.get(2).setText(port.externalReferenceDesignator());
     }
 }

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIProcessorPanelWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIProcessorPanelWorker.java
@@ -4,10 +4,10 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.compounded.Win32ProcessorToCacheMemory;
-import io.github.eggy03.ferrumx.windows.entity.processor.Win32CacheMemory;
-import io.github.eggy03.ferrumx.windows.entity.processor.Win32Processor;
-import io.github.eggy03.ferrumx.windows.service.compounded.Win32ProcessorToCacheMemoryService;
+import io.github.eggy03.cimari.entity.compounded.Win32ProcessorToCacheMemory;
+import io.github.eggy03.cimari.entity.processor.Win32CacheMemory;
+import io.github.eggy03.cimari.entity.processor.Win32Processor;
+import io.github.eggy03.cimari.service.compounded.Win32ProcessorToCacheMemoryService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.constant.WMIConstants;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +19,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -53,7 +54,7 @@ public class WMIProcessorPanelWorker extends SwingWorker<List<Win32ProcessorToCa
             log.info("Found {} Win32Processor entry/entries", cpuAndCacheList.size());
 
             // populate the combo box with cpu device id
-            cpuAndCacheList.forEach(cpuAndCache -> cpuIdComboBox.addItem(cpuAndCache.getDeviceId()));
+            cpuAndCacheList.forEach(cpuAndCache -> cpuIdComboBox.addItem(cpuAndCache.deviceId()));
             // populate fields for the first entry in the combo box
             populateFieldsBasedOnCurrentCpuId(cpuAndCacheList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -71,48 +72,49 @@ public class WMIProcessorPanelWorker extends SwingWorker<List<Win32ProcessorToCa
     	
     	// filter a cpuAndCacheObject based on the cpu id in the combo box
     	Optional<Win32ProcessorToCacheMemory> current = cpuAndCacheList.stream()
-                .filter(cpuAndCache -> cpuAndCache.getDeviceId()!=null && cpuAndCache.getDeviceId().equals(cpuIdComboBox.getSelectedItem()))
+                .filter(Objects::nonNull)
+                .filter(cpuAndCache -> Objects.equals(cpuAndCache.deviceId(), cpuIdComboBox.getSelectedItem()))
                 .findFirst();
 
         if (current.isEmpty())
             return;
 
         Win32ProcessorToCacheMemory currentCpuAndCache = current.get();
-        Win32Processor currentCpu = currentCpuAndCache.getProcessor();
-        List<Win32CacheMemory> currentCacheList = currentCpuAndCache.getCacheMemoryList();
+        Win32Processor currentCpu = currentCpuAndCache.processor();
+        List<Win32CacheMemory> currentCacheList = currentCpuAndCache.cacheMemoryList();
         
         // populate cpu fields
         if(currentCpu!=null) { // the order is maintained by the order in which the text fields have been passed to its constructor
-        	cpuFields.get(0).setText(String.valueOf(currentCpu.getNumberOfCores()));
-        	cpuFields.get(1).setText(String.valueOf(currentCpu.getThreadCount()));
-        	cpuFields.get(2).setText(currentCpu.getMaxClockSpeed()+" MHz");
-        	cpuFields.get(3).setText(currentCpu.getName());
-        	cpuFields.get(4).setText(currentCpu.getVersion());
-        	cpuFields.get(5).setText(String.valueOf(currentCpu.getFamily()));
-        	cpuFields.get(6).setText(currentCpu.getStepping());
-        	cpuFields.get(7).setText(currentCpu.getManufacturer());
-        	cpuFields.get(8).setText(currentCpu.getCaption());
-        	cpuFields.get(9).setText(currentCpu.getProcessorId());
-        	cpuFields.get(10).setText(String.valueOf(currentCpu.getNumberOfEnabledCores()));
-        	cpuFields.get(11).setText(String.valueOf(currentCpu.getNumberOfLogicalProcessors()));
-        	cpuFields.get(12).setText(WMIConstants.processorArchitecture(currentCpu.getArchitecture()));
-        	cpuFields.get(13).setText(currentCpu.getAddressWidth()+" bit");
-        	cpuFields.get(14).setText(String.valueOf(currentCpu.getSocketDesignation()));
-        	cpuFields.get(15).setText(currentCpu.getExtClock()+ " MHz");
+        	cpuFields.get(0).setText(String.valueOf(currentCpu.numberOfCores()));
+        	cpuFields.get(1).setText(String.valueOf(currentCpu.threadCount()));
+        	cpuFields.get(2).setText(currentCpu.maxClockSpeed()+" MHz");
+        	cpuFields.get(3).setText(currentCpu.name());
+        	cpuFields.get(4).setText(currentCpu.version());
+        	cpuFields.get(5).setText(String.valueOf(currentCpu.family()));
+        	cpuFields.get(6).setText(currentCpu.stepping());
+        	cpuFields.get(7).setText(currentCpu.manufacturer());
+        	cpuFields.get(8).setText(currentCpu.caption());
+        	cpuFields.get(9).setText(currentCpu.processorId());
+        	cpuFields.get(10).setText(String.valueOf(currentCpu.numberOfEnabledCores()));
+        	cpuFields.get(11).setText(String.valueOf(currentCpu.numberOfLogicalProcessors()));
+        	cpuFields.get(12).setText(WMIConstants.processorArchitecture(currentCpu.architecture()));
+        	cpuFields.get(13).setText(currentCpu.addressWidth()+" bit");
+        	cpuFields.get(14).setText(String.valueOf(currentCpu.socketDesignation()));
+        	cpuFields.get(15).setText(currentCpu.extClock()+ " MHz");
         	
         	// assign text to the concise cpu text area
             JTextArea conciseCpuTextArea = cpuTextAreas.getFirst();
-            String conciseText = "This CPU, " + String.valueOf(currentCpu.getName()).trim() + " consists of "
+            String conciseText = "This CPU, " + String.valueOf(currentCpu.name()).trim() + " consists of "
                     + System.lineSeparator() +
-                    currentCpu.getNumberOfCores() + " cores and " + currentCpu.getThreadCount() + " threads, out of which "
+                    currentCpu.numberOfCores() + " cores and " + currentCpu.threadCount() + " threads, out of which "
                     + System.lineSeparator() +
-                    currentCpu.getNumberOfEnabledCores() + " cores and " + currentCpu.getNumberOfLogicalProcessors() + " threads are enabled."
+                    currentCpu.numberOfEnabledCores() + " cores and " + currentCpu.numberOfLogicalProcessors() + " threads are enabled."
                     + System.lineSeparator() +
-                    "The factory reported base clock for this CPU is: " + currentCpu.getMaxClockSpeed() + " MHz."
+                    "The factory reported base clock for this CPU is: " + currentCpu.maxClockSpeed() + " MHz."
                     + System.lineSeparator() +
-                    "The reported socket for this CPU is: " + currentCpu.getSocketDesignation()
+                    "The reported socket for this CPU is: " + currentCpu.socketDesignation()
                     + System.lineSeparator() +
-                    "The reported L2 Cache is: " + currentCpu.getL2CacheSize()+ " KB and the reported L3 Cache is: "+currentCpu.getL3CacheSize() + " KB.";
+                    "The reported L2 Cache is: " + currentCpu.l2CacheSize()+ " KB and the reported L3 Cache is: "+currentCpu.l3CacheSize() + " KB.";
 
             conciseCpuTextArea.setText(conciseText);
         }
@@ -124,16 +126,16 @@ public class WMIProcessorPanelWorker extends SwingWorker<List<Win32ProcessorToCa
             JTextArea cacheTextArea = cpuTextAreas.get(1);
             cacheTextArea.setText(null); //before populating, clean the previous data if any
             currentCacheList.forEach(cache -> cacheTextArea.append(
-                    "DeviceID: "+cache.getDeviceId()+System.lineSeparator()+
-                    "Purpose: "+cache.getPurpose()+System.lineSeparator()+
-                    "Type: "+resolveWMICacheMemoryType(cache.getCacheType())+System.lineSeparator()+
-                    "Level: "+resolveWMICacheMemoryLevel(cache.getLevel())+System.lineSeparator()+
-                    "Size: "+cache.getInstalledSize()+" KB"+System.lineSeparator()+
-                    "Associativity: "+resolveWMICacheMemoryAssociativity(cache.getAssociativity())+System.lineSeparator()+
-                    "Location: "+resolveWMICacheMemoryLocation(cache.getLocation())+System.lineSeparator()+
-                    "Error Correct Type: "+resolveWMICacheErrorCorrectType(cache.getErrorCorrectType())+System.lineSeparator()+
-                    "Availability: "+resolveWMIAvailability(cache.getAvailability())+System.lineSeparator()+
-                    "Status: "+cache.getStatus()+System.lineSeparator()+System.lineSeparator()
+                    "DeviceID: "+cache.deviceId()+System.lineSeparator()+
+                    "Purpose: "+cache.purpose()+System.lineSeparator()+
+                    "Type: "+resolveWMICacheMemoryType(cache.cacheType())+System.lineSeparator()+
+                    "Level: "+resolveWMICacheMemoryLevel(cache.level())+System.lineSeparator()+
+                    "Size: "+cache.installedSize()+" KB"+System.lineSeparator()+
+                    "Associativity: "+resolveWMICacheMemoryAssociativity(cache.associativity())+System.lineSeparator()+
+                    "Location: "+resolveWMICacheMemoryLocation(cache.location())+System.lineSeparator()+
+                    "Error Correct Type: "+resolveWMICacheErrorCorrectType(cache.errorCorrectType())+System.lineSeparator()+
+                    "Availability: "+resolveWMIAvailability(cache.availability())+System.lineSeparator()+
+                    "Status: "+cache.status()+System.lineSeparator()+System.lineSeparator()
             ));
         }
     }

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIStorageWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIStorageWorker.java
@@ -4,11 +4,11 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.compounded.Win32DiskDriveToPartitionAndLogicalDisk;
-import io.github.eggy03.ferrumx.windows.entity.storage.Win32DiskDrive;
-import io.github.eggy03.ferrumx.windows.entity.storage.Win32DiskPartition;
-import io.github.eggy03.ferrumx.windows.entity.storage.Win32LogicalDisk;
-import io.github.eggy03.ferrumx.windows.service.compounded.Win32DiskDriveToPartitionAndLogicalDiskService;
+import io.github.eggy03.cimari.entity.compounded.Win32DiskDriveToPartitionAndLogicalDisk;
+import io.github.eggy03.cimari.entity.storage.Win32DiskDrive;
+import io.github.eggy03.cimari.entity.storage.Win32DiskPartition;
+import io.github.eggy03.cimari.entity.storage.Win32LogicalDisk;
+import io.github.eggy03.cimari.service.compounded.Win32DiskDriveToPartitionAndLogicalDiskService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.constant.WMIConstants;
 import io.github.eggy03.ui.windows.utilities.WMIBooleanUtility;
@@ -21,6 +21,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -48,7 +49,7 @@ public class WMIStorageWorker extends SwingWorker<List<Win32DiskDriveToPartition
             log.info("Found {} Win32DiskDrive entry/entries", diskList.size());
 
             // populate the combo box with disk deviceIDs
-            diskList.forEach(disk-> diskIdComboBox.addItem(disk.getDeviceId()));
+            diskList.forEach(disk-> diskIdComboBox.addItem(disk.deviceId()));
             // populate fields and editor panes for the first entry in the combo box
             populate(diskList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -68,28 +69,29 @@ public class WMIStorageWorker extends SwingWorker<List<Win32DiskDriveToPartition
 
         Optional<Win32DiskDriveToPartitionAndLogicalDisk> optionalDisk = diskList
                 .stream()
-                .filter(disk-> disk.getDeviceId()!=null && disk.getDeviceId().equals(selectedDiskId))
+                .filter(Objects::nonNull)
+                .filter(disk-> Objects.equals(disk.deviceId(), selectedDiskId))
                 .findFirst();
 
         if(optionalDisk.isEmpty())
             return;
 
         Win32DiskDriveToPartitionAndLogicalDisk disk = optionalDisk.get();
-        Win32DiskDrive diskDrive = disk.getDiskDrive();
-        List<Win32DiskPartition> diskPartitionList = disk.getDiskPartitionList();
-        List<Win32LogicalDisk> logicalDiskList = disk.getLogicalDiskList();
+        Win32DiskDrive diskDrive = disk.diskDrive();
+        List<Win32DiskPartition> diskPartitionList = disk.diskPartitionList();
+        List<Win32LogicalDisk> logicalDiskList = disk.logicalDiskList();
 
         if(diskDrive!=null) {
-            diskFields.get(0).setText(diskDrive.getPnpDeviceId());
-            diskFields.get(1).setText(diskDrive.getCaption());
-            diskFields.get(2).setText(diskDrive.getModel());
-            diskFields.get(3).setText(diskDrive.getFirmwareRevision());
-            diskFields.get(4).setText(diskDrive.getInterfaceType());
-            diskFields.get(5).setText(String.valueOf(diskDrive.getSerialNumber()).trim());
-            diskFields.get(6).setText(WMISizeUtility.parseToGBString(diskDrive.getSize()));
-            diskFields.get(7).setText(String.valueOf(diskDrive.getPartitions()));
-            diskFields.get(8).setText(diskDrive.getCapabilityDescriptions()==null ? "N/A" : diskDrive.getCapabilityDescriptions().toString());
-            diskFields.get(9).setText(diskDrive.getStatus());
+            diskFields.get(0).setText(diskDrive.pnpDeviceId());
+            diskFields.get(1).setText(diskDrive.caption());
+            diskFields.get(2).setText(diskDrive.model());
+            diskFields.get(3).setText(diskDrive.firmwareRevision());
+            diskFields.get(4).setText(diskDrive.interfaceType());
+            diskFields.get(5).setText(String.valueOf(diskDrive.serialNumber()).trim());
+            diskFields.get(6).setText(WMISizeUtility.parseToGBString(diskDrive.size()));
+            diskFields.get(7).setText(String.valueOf(diskDrive.partitions()));
+            diskFields.get(8).setText(diskDrive.capabilityDescriptions()==null ? "N/A" : diskDrive.capabilityDescriptions().toString());
+            diskFields.get(9).setText(diskDrive.status());
         }
 
         JEditorPane partitionPane = diskEditorPanes.get(0);
@@ -103,17 +105,17 @@ public class WMIStorageWorker extends SwingWorker<List<Win32DiskDriveToPartition
             stringBuilder.append("<html><body>");
 
             diskPartitionList.forEach(partition -> stringBuilder
-                    .append("<b>Device ID:</b> ").append(partition.getDeviceId()).append("<br>")
-                    .append("<b>Name:</b> ").append(partition.getName()).append("<br>")
-                    .append("<b>Description:</b> ").append(partition.getDescription()).append("<br>")
-                    .append("<b>Disk Index:</b> ").append(partition.getDiskIndex()).append("<br>")
-                    .append("<b>Type:</b> ").append(partition.getType()).append("<br>")
-                    .append("<b>Bootable:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.isBootable())).append("<br>")
-                    .append("<b>Primary Partition:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.isPrimaryPartition())).append("<br>")
-                    .append("<b>Boot Partition:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.isBootPartition())).append("<br>")
-                    .append("<b>Block Size (bytes):</b> ").append(partition.getBlockSize()).append("<br>")
-                    .append("<b>Number of Blocks:</b> ").append(partition.getNumberOfBlocks()).append("<br>")
-                    .append("<b>Total Size:</b> ").append(WMISizeUtility.parseToGBString(partition.getSize()))
+                    .append("<b>Device ID:</b> ").append(partition.deviceId()).append("<br>")
+                    .append("<b>Name:</b> ").append(partition.name()).append("<br>")
+                    .append("<b>Description:</b> ").append(partition.description()).append("<br>")
+                    .append("<b>Disk Index:</b> ").append(partition.diskIndex()).append("<br>")
+                    .append("<b>Type:</b> ").append(partition.type()).append("<br>")
+                    .append("<b>Bootable:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.bootable())).append("<br>")
+                    .append("<b>Primary Partition:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.primaryPartition())).append("<br>")
+                    .append("<b>Boot Partition:</b> ").append(WMIBooleanUtility.resolveBoolean(partition.bootPartition())).append("<br>")
+                    .append("<b>Block Size (bytes):</b> ").append(partition.blockSize()).append("<br>")
+                    .append("<b>Number of Blocks:</b> ").append(partition.numberOfBlocks()).append("<br>")
+                    .append("<b>Total Size:</b> ").append(WMISizeUtility.parseToGBString(partition.size()))
                     .append("<br><br>")
             );
 
@@ -126,18 +128,18 @@ public class WMIStorageWorker extends SwingWorker<List<Win32DiskDriveToPartition
             stringBuilder.append("<html><body>");
 
             logicalDiskList.forEach(logicalDisk -> stringBuilder
-                    .append("<b>Device ID:</b> ").append(logicalDisk.getDeviceId()).append("<br>")
-                    .append("<b>Volume Name:</b> ").append(logicalDisk.getVolumeName()).append("<br>")
-                    .append("<b>Description:</b> ").append(logicalDisk.getDescription()).append("<br>")
-                    .append("<b>Drive Type:</b> ").append(WMIConstants.resolveWMILogicalDiskDriveType(logicalDisk.getDriveType())).append("<br>")
-                    .append("<b>Media Type:</b> ").append(WMIConstants.resolveWMILogicalDiskMediaType(logicalDisk.getMediaType())).append("<br>")
-                    .append("<b>File System:</b> ").append(logicalDisk.getFileSystem()).append("<br>")
-                    .append("<b>Total Size:</b> ").append(WMISizeUtility.parseToGBString(logicalDisk.getSize())).append("<br>")
-                    .append("<b>Free Space:</b> ").append(WMISizeUtility.parseToGBString(logicalDisk.getFreeSpace())).append("<br>")
-                    .append("<b>Compressed:</b> ").append(WMIBooleanUtility.resolveBoolean(logicalDisk.isCompressed())).append("<br>")
+                    .append("<b>Device ID:</b> ").append(logicalDisk.deviceId()).append("<br>")
+                    .append("<b>Volume Name:</b> ").append(logicalDisk.volumeName()).append("<br>")
+                    .append("<b>Description:</b> ").append(logicalDisk.description()).append("<br>")
+                    .append("<b>Drive Type:</b> ").append(WMIConstants.resolveWMILogicalDiskDriveType(logicalDisk.driveType())).append("<br>")
+                    .append("<b>Media Type:</b> ").append(WMIConstants.resolveWMILogicalDiskMediaType(logicalDisk.mediaType())).append("<br>")
+                    .append("<b>File System:</b> ").append(logicalDisk.fileSystem()).append("<br>")
+                    .append("<b>Total Size:</b> ").append(WMISizeUtility.parseToGBString(logicalDisk.size())).append("<br>")
+                    .append("<b>Free Space:</b> ").append(WMISizeUtility.parseToGBString(logicalDisk.freeSpace())).append("<br>")
+                    .append("<b>Compressed:</b> ").append(WMIBooleanUtility.resolveBoolean(logicalDisk.compressed())).append("<br>")
                     .append("<b>Supports File Compression:</b> ").append(WMIBooleanUtility.resolveBoolean(logicalDisk.supportsFileBasedCompression())).append("<br>")
                     .append("<b>Supports Disk Quotas:</b> ").append(WMIBooleanUtility.resolveBoolean(logicalDisk.supportsDiskQuotas())).append("<br>")
-                    .append("<b>Volume Serial Number:</b> ").append(logicalDisk.getVolumeSerialNumber())
+                    .append("<b>Volume Serial Number:</b> ").append(logicalDisk.volumeSerialNumber())
                     .append("<br><br>")
             );
 

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIUserAccountWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIUserAccountWorker.java
@@ -4,8 +4,8 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.user.Win32UserAccount;
-import io.github.eggy03.ferrumx.windows.service.user.Win32UserAccountService;
+import io.github.eggy03.cimari.entity.user.Win32UserAccount;
+import io.github.eggy03.cimari.service.user.Win32UserAccountService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.constant.WMIConstants;
 import io.github.eggy03.ui.windows.utilities.WMIBooleanUtility;
@@ -16,6 +16,7 @@ import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -42,7 +43,7 @@ public class WMIUserAccountWorker extends SwingWorker<List<Win32UserAccount>, Vo
             log.info("Found {} Win32UserAccount entry/entries", userAccountList.size());
 
             // fill the combo box with user account SIDs
-            userAccountList.forEach(account ->userAccountSIDComboBox.addItem(account.getSid()));
+            userAccountList.forEach(account ->userAccountSIDComboBox.addItem(account.sid()));
             // populate fields for the first entry in the combo box
             populateFields(userAccountList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -61,7 +62,8 @@ public class WMIUserAccountWorker extends SwingWorker<List<Win32UserAccount>, Vo
 
         Optional<Win32UserAccount> optionalAccount = userAccountList
                 .stream()
-                .filter(account-> account.getSid()!=null && account.getSid().equals(userAccountSid))
+                .filter(Objects::nonNull)
+                .filter(account-> Objects.equals(account.sid(), userAccountSid))
                 .findFirst();
 
         if(optionalAccount.isEmpty())
@@ -69,18 +71,18 @@ public class WMIUserAccountWorker extends SwingWorker<List<Win32UserAccount>, Vo
 
         Win32UserAccount account = optionalAccount.get();
 
-        userAccountFields.get(0).setText(account.getName());
-        userAccountFields.get(1).setText(account.getCaption());
-        userAccountFields.get(2).setText(account.getDomain());
-        userAccountFields.get(3).setText(account.getDescription());
-        userAccountFields.get(4).setText(WMIBooleanUtility.resolveBoolean(account.isPasswordRequired()));
-        userAccountFields.get(5).setText(WMIBooleanUtility.resolveBoolean(account.isPasswordChangeable()));
-        userAccountFields.get(6).setText(WMIBooleanUtility.resolveBoolean(account.doesPasswordExpire()));
-        userAccountFields.get(7).setText(WMIBooleanUtility.resolveBoolean(account.isLocalAccount()));
-        userAccountFields.get(8).setText(WMIBooleanUtility.resolveBoolean(account.isDisabled()));
-        userAccountFields.get(9).setText(WMIBooleanUtility.resolveBoolean(account.isLockedOut()));
-        userAccountFields.get(10).setText(WMIConstants.resolveWMIUserAccountType(account.getAccountType()));
-        userAccountFields.get(11).setText(WMIConstants.resolveWMIUserAccountSidType(account.getSidType()));
-        userAccountFields.get(12).setText(account.getStatus());
+        userAccountFields.get(0).setText(account.name());
+        userAccountFields.get(1).setText(account.caption());
+        userAccountFields.get(2).setText(account.domain());
+        userAccountFields.get(3).setText(account.description());
+        userAccountFields.get(4).setText(WMIBooleanUtility.resolveBoolean(account.passwordRequired()));
+        userAccountFields.get(5).setText(WMIBooleanUtility.resolveBoolean(account.passwordChangeable()));
+        userAccountFields.get(6).setText(WMIBooleanUtility.resolveBoolean(account.passwordExpires()));
+        userAccountFields.get(7).setText(WMIBooleanUtility.resolveBoolean(account.localAccount()));
+        userAccountFields.get(8).setText(WMIBooleanUtility.resolveBoolean(account.disabled()));
+        userAccountFields.get(9).setText(WMIBooleanUtility.resolveBoolean(account.lockout()));
+        userAccountFields.get(10).setText(WMIConstants.resolveWMIUserAccountType(account.accountType()));
+        userAccountFields.get(11).setText(WMIConstants.resolveWMIUserAccountSidType(account.sidType()));
+        userAccountFields.get(12).setText(account.status());
     }
 }

--- a/src/main/java/io/github/eggy03/ui/windows/worker/WMIVideoControllerPanelWorker.java
+++ b/src/main/java/io/github/eggy03/ui/windows/worker/WMIVideoControllerPanelWorker.java
@@ -4,8 +4,8 @@
  */
 package io.github.eggy03.ui.windows.worker;
 
-import io.github.eggy03.ferrumx.windows.entity.display.Win32VideoController;
-import io.github.eggy03.ferrumx.windows.service.display.Win32VideoControllerService;
+import io.github.eggy03.cimari.entity.display.Win32VideoController;
+import io.github.eggy03.cimari.service.display.Win32VideoControllerService;
 import io.github.eggy03.ui.common.constant.TerminalConstant;
 import io.github.eggy03.ui.windows.utilities.WMIDateUtility;
 import io.github.eggy03.ui.windows.utilities.WMISizeUtility;
@@ -16,6 +16,7 @@ import javax.swing.JComboBox;
 import javax.swing.JTextField;
 import javax.swing.SwingWorker;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -42,7 +43,7 @@ public class WMIVideoControllerPanelWorker extends SwingWorker<List<Win32VideoCo
             log.info("Found {} Win32VideoController entry/entries", videoControllerList.size());
 
             // fill video controller IDs in the combo box
-            videoControllerList.forEach(v -> gpuDeviceIdComboBox.addItem(v.getDeviceId()));
+            videoControllerList.forEach(v -> gpuDeviceIdComboBox.addItem(v.deviceId()));
             // populate fields for the first entry in the combo box
             populateFields(videoControllerList);
             // add a listener to the combo box to re-populate fields on new selection
@@ -61,25 +62,26 @@ public class WMIVideoControllerPanelWorker extends SwingWorker<List<Win32VideoCo
         String gpuDeviceId = String.valueOf(gpuDeviceIdComboBox.getSelectedItem());
         Optional<Win32VideoController> optionalGpu = videoControllerList
                 .stream()
-                .filter(v -> v.getDeviceId() != null && v.getDeviceId().equals(gpuDeviceId))
+                .filter(Objects::nonNull)
+                .filter(v -> Objects.equals(v.deviceId(), gpuDeviceId))
                 .findFirst();
 
         if (optionalGpu.isEmpty())
             return;
 
         Win32VideoController gpu = optionalGpu.get();
-        gpuFields.get(0).setText(gpu.getName());
-        gpuFields.get(1).setText(gpu.getPnpDeviceId());
-        gpuFields.get(2).setText(gpu.getCurrentHorizontalResolution() + " px");
-        gpuFields.get(3).setText(gpu.getCurrentVerticalResolution() + " px");
-        gpuFields.get(4).setText(gpu.getCurrentBitsPerPixel() + " bit");
-        gpuFields.get(5).setText(gpu.getMinRefreshRate() + " Hz");
-        gpuFields.get(6).setText(gpu.getMaxRefreshRate() + " Hz");
-        gpuFields.get(7).setText(gpu.getCurrentRefreshRate() + " Hz");
-        gpuFields.get(8).setText(gpu.getAdapterDacType());
-        gpuFields.get(9).setText(WMISizeUtility.parseToGBString(gpu.getAdapterRam()));
-        gpuFields.get(10).setText(gpu.getDriverVersion());
-        gpuFields.get(11).setText(WMIDateUtility.toLocalDateTime(gpu.getDriverDate()));
-        gpuFields.get(12).setText(gpu.getVideoProcessor());
+        gpuFields.get(0).setText(gpu.name());
+        gpuFields.get(1).setText(gpu.pnpDeviceId());
+        gpuFields.get(2).setText(gpu.currentHorizontalResolution() + " px");
+        gpuFields.get(3).setText(gpu.currentVerticalResolution() + " px");
+        gpuFields.get(4).setText(gpu.currentBitsPerPixel() + " bit");
+        gpuFields.get(5).setText(gpu.minRefreshRate() + " Hz");
+        gpuFields.get(6).setText(gpu.maxRefreshRate() + " Hz");
+        gpuFields.get(7).setText(gpu.currentRefreshRate() + " Hz");
+        gpuFields.get(8).setText(gpu.adapterDacType());
+        gpuFields.get(9).setText(WMISizeUtility.parseToGBString(gpu.adapterRam()));
+        gpuFields.get(10).setText(gpu.driverVersion());
+        gpuFields.get(11).setText(WMIDateUtility.toLocalDateTime(gpu.driverDate()));
+        gpuFields.get(12).setText(gpu.videoProcessor());
     }
 }

--- a/src/main/resources/OpenSourceLicenses.txt
+++ b/src/main/resources/OpenSourceLicenses.txt
@@ -5,7 +5,7 @@ This application includes third-party open-source software.
 The following libraries are used under their respective licenses.
 
 ------------------------------------------------------------
-FerrumX Windows, dmidecode4j, Swing Theme Manager
+cimari, dmidecode4j, Swing Theme Manager
 ------------------------------------------------------------
 MIT License
 


### PR DESCRIPTION
- Update dependency `ferrumx-windows` to `cimari` in `pom.xml`.
- Update import statements across various worker classes to reflect the new package name `io.github.eggy03.cimari`.
- Update getter method calls from `getFieldName()` to `fieldName()` for immutability and consistency with the new library.
- Update builder methods to adapt to cimari's style.
- Update open source licenses and AboutUI to replace ferrumx-windows with cimari